### PR TITLE
feat: Add SBS 3D video mode

### DIFF
--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -59,6 +59,10 @@ struct RealityKitStreamView: View {
     @State var texture: TextureResource
     @State var screen: ModelEntity = ModelEntity()
 
+    @State var videoMode: VideoMode = .standard2D
+
+    @State private var surfaceMaterial: ShaderGraphMaterial?
+
     init(streamConfig: Binding<StreamConfiguration>) {
         self._streamConfig = streamConfig
         self.controllerSupport = ControllerSupport(config: streamConfig.wrappedValue, delegate: DummyControllerDelegate())
@@ -79,7 +83,27 @@ struct RealityKitStreamView: View {
                 RealityView { content in
                     let mesh = try! RealityKitStreamView.generateCurvedPlane(width: MAX_WIDTH_METERS, aspectRatio: aspectRatio, resulotion: (50,50), curveMagnitude: viewModel.streamSettings.realitykitRendererCurvature * curveAnimationMultiplier)
                     let colBox = ShapeResource.generateBox(width: 2, height: 2 * aspectRatio, depth: 0.001).offsetBy(translation: .init(x: 0, y: -0.43, z: 1))
-                    screen = ModelEntity(mesh: mesh, materials: [UnlitMaterial(texture: self.texture)])
+                    screen = ModelEntity(mesh: mesh, materials: [])
+
+                    // Initialize material if needed
+                    if surfaceMaterial == nil {
+                        surfaceMaterial = try! await ShaderGraphMaterial(
+                            named: "/Root/SBSMaterial",
+                            from: "SBSMaterial.usda"
+                        )
+
+                        try! surfaceMaterial!.setParameter(
+                            name: "texture",
+                            value: .textureResource(self.texture)
+                        )
+                    }
+
+                    if videoMode == .sideBySide3D {
+                        screen.model?.materials = [surfaceMaterial!]
+                    } else {
+                        screen.model?.materials = [UnlitMaterial(texture: self.texture)]
+                    }
+
                     screen.collision = CollisionComponent(shapes: [
                         colBox
                     ], mode: .colliding)
@@ -130,6 +154,16 @@ struct RealityKitStreamView: View {
                             ))
                             //                            effect.scaleEffect(x: isActive ? 1: 0.5, y: 1, anchor: .leading)
                         }
+                }
+                HStack {
+                    Button("3D Mode", systemImage: videoMode == .standard2D ? "rectangle" : "rectangle.split.2x1") {
+                        videoMode = videoMode == .standard2D ? .sideBySide3D : .standard2D
+                        if videoMode == .sideBySide3D {
+                            screen.model?.materials = [surfaceMaterial!]
+                        } else {
+                            screen.model?.materials = [UnlitMaterial(texture: texture)]
+                        }
+                    }
                 }
                 HStack {
                     Button("arrow.up.and.line.horizontal.and.arrow.down", systemImage: "arrow.up.and.line.horizontal.and.arrow.down") {

--- a/Moonlight Vision/SBSMaterial.usda
+++ b/Moonlight Vision/SBSMaterial.usda
@@ -1,0 +1,84 @@
+#usda 1.0
+(
+    customLayerData = {
+        string creator = "Reality Composer Pro Version 1.0 (409.60.6)"
+    }
+    defaultPrim = "Root"
+    metersPerUnit = 1
+    upAxis = "Y"
+)
+
+def Xform "Root"
+{
+    def Material "SBSMaterial"
+    {
+        asset inputs:texture (
+            customData = {
+                dictionary realitykit = {
+                    float2 positionInSubgraph = (-714.7617, 37.04297)
+                    float2 sizeInSubgraph = (115.5, 53)
+                    int stackingOrderInSubgraph = 80
+                }
+            }
+        )
+        token outputs:mtlx:surface.connect = </Root/SBSMaterial/UnlitPreviewSurface.outputs:out>
+        token outputs:realitykit:vertex
+        float2 ui:nodegraph:realitykit:subgraphOutputs:pos = (570.13995, 229.80997)
+        float2 ui:nodegraph:realitykit:subgraphOutputs:size = (181.5, 99)
+        int ui:nodegraph:realitykit:subgraphOutputs:stackingOrder = 69
+
+        def Shader "GeometrySwitchCameraIndex"
+        {
+            uniform token info:id = "ND_realitykit_geometry_switch_cameraindex_color3"
+            color3f inputs:left.connect = </Root/SBSMaterial/Left.outputs:out>
+            color3f inputs:mono.connect = </Root/SBSMaterial/Left.outputs:out>
+            color3f inputs:right.connect = </Root/SBSMaterial/Right.outputs:out>
+            color3f outputs:out
+            float2 ui:nodegraph:node:pos = (-23.292734, 86.06585)
+            float2 ui:nodegraph:node:size = (237, 145)
+            int ui:nodegraph:node:stackingOrder = 79
+        }
+
+        def Shader "Left"
+        {
+            uniform token info:id = "ND_tiledimage_color3"
+            asset inputs:file.connect = </Root/SBSMaterial.inputs:texture>
+            string inputs:filtertype
+            float2 inputs:uvtiling = (0.5, 1)
+            color3f outputs:out
+            float2 ui:nodegraph:node:pos = (-405.69922, 10.6875)
+            float2 ui:nodegraph:node:size = (158.5, 235)
+            int ui:nodegraph:node:stackingOrder = 80
+        }
+
+        def Shader "Right"
+        {
+            uniform token info:id = "ND_tiledimage_color3"
+            color3f inputs:default
+            asset inputs:file.connect = </Root/SBSMaterial.inputs:texture>
+            string inputs:filtertype
+            float2 inputs:realworldimagesize
+            float2 inputs:realworldtilesize
+            float2 inputs:texcoord
+            float2 inputs:uvoffset = (0.5, 0)
+            float2 inputs:uvtiling = (0.5, 1)
+            color3f outputs:out
+            float2 ui:nodegraph:node:pos = (-409.65234, 275.46094)
+            float2 ui:nodegraph:node:size = (158.5, 235)
+            int ui:nodegraph:node:stackingOrder = 187
+        }
+
+        def Shader "UnlitPreviewSurface"
+        {
+            uniform token info:id = "ND_realitykit_unlit_surfaceshader"
+            color3f inputs:color.connect = </Root/SBSMaterial/GeometrySwitchCameraIndex.outputs:out>
+            bool inputs:hasPremultipliedAlpha
+            float inputs:opacity
+            float inputs:opacityThreshold
+            token outputs:out
+            float2 ui:nodegraph:node:pos = (289.84146, -36.195312)
+            int ui:nodegraph:node:stackingOrder = 206
+        }
+    }
+}
+

--- a/Moonlight Vision/VideoTypes.swift
+++ b/Moonlight Vision/VideoTypes.swift
@@ -1,0 +1,11 @@
+//
+//  VideoTypes.swift
+//  Moonlight Vision
+//
+
+import Foundation
+
+enum VideoMode {
+    case standard2D
+    case sideBySide3D
+}

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		3E86FC1D2D4FFDF20016BB8E /* UpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E86FC1C2D4FFDED0016BB8E /* UpdatesView.swift */; };
 		3E9440F62D4EB9ED0047E0C2 /* OpenSSL in Frameworks */ = {isa = PBXBuildFile; productRef = 3E9440F52D4EB9ED0047E0C2 /* OpenSSL */; };
+		6581B5F12D5434100022400F /* VideoTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581B5F02D5434100022400F /* VideoTypes.swift */; };
+		659789EC2D55A93A00B88B25 /* SBSMaterial.usda in Resources */ = {isa = PBXBuildFile; fileRef = 659789EB2D55A93A00B88B25 /* SBSMaterial.usda */; };
 		693B3A9B218638CD00982F7B /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 693B3A9A218638CD00982F7B /* Settings.bundle */; };
 		98181BE92791277400E43572 /* libSDL2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 98181BE82791275D00E43572 /* libSDL2.a */; };
 		98181BEB2791278F00E43572 /* libSDL2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 98181BEA2791278300E43572 /* libSDL2.a */; };
@@ -276,6 +278,8 @@
 /* Begin PBXFileReference section */
 		3E86FC1C2D4FFDED0016BB8E /* UpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesView.swift; sourceTree = "<group>"; };
 		566E9D2B2770B23A00EF7BFE /* Moonlight v1.7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Moonlight v1.7.xcdatamodel"; sourceTree = "<group>"; };
+		6581B5F02D5434100022400F /* VideoTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTypes.swift; sourceTree = "<group>"; };
+		659789EB2D55A93A00B88B25 /* SBSMaterial.usda */ = {isa = PBXFileReference; lastKnownFileType = text; path = SBSMaterial.usda; sourceTree = "<group>"; };
 		693B3A9A218638CD00982F7B /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		9803CCAB254F9EAF00EE185E /* ConnectionCallbacks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConnectionCallbacks.h; sourceTree = "<group>"; };
 		98132E8C20BC9A62007A053F /* Moonlight v1.1.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Moonlight v1.1.xcdatamodel"; sourceTree = "<group>"; };
@@ -635,6 +639,8 @@
 		F7A119592B5DE1AB001E8686 /* Moonlight Vision */ = {
 			isa = PBXGroup;
 			children = (
+				659789EB2D55A93A00B88B25 /* SBSMaterial.usda */,
+				6581B5F02D5434100022400F /* VideoTypes.swift */,
 				3E86FC1C2D4FFDED0016BB8E /* UpdatesView.swift */,
 				B1EDB1302D4D95A700EB1839 /* DrawableVideoDecoder.swift */,
 				B1EDB1312D4D95A700EB1839 /* ObservableConnectionManager.swift */,
@@ -1216,6 +1222,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F7A1194E2B5DDF73001E8686 /* InfoPlist.strings in Resources */,
+				659789EC2D55A93A00B88B25 /* SBSMaterial.usda in Resources */,
 				F7A119502B5DDF73001E8686 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1250,6 +1257,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6581B5F12D5434100022400F /* VideoTypes.swift in Sources */,
 				B19362F02D4ECDD6004F88FA /* NSData+Conversion.m in Sources */,
 				F7A1190C2B5DDF73001E8686 /* Limelight.xcdatamodeld in Sources */,
 				F7A1190D2B5DDF73001E8686 /* AbsoluteTouchHandler.m in Sources */,


### PR DESCRIPTION
Adds a ShaderGraphMaterial that splits the texture in half and displays the halves in stereo. The shader was pulled from [KhaosT's example](https://github.com/KhaosT/RealityKitSideBySideRenderExample) though that uses a metallic surface which messes up the colors. This works pretty flawlessly with half-width side-by-side video, performing better than Moon Video playing the same [example video](https://vimeo.com/167717612). It can probably be extended to handle full-width side-by-side video which would provide much better quality.

I've tested it with quite a bit of Half-Life 2 + Reshade, as well as Rise of the Tomb Raider's built in side-by-side 3D. All of the caveats of half-width side-by-side 3D apply: you're losing half the resolution. I only added this to the  not attempt to add this to `RealityKitStreamView` because I assumed it couldn't use the ShaderGraphMaterial, but I didn't actually check.